### PR TITLE
Remove special comment used to identify immutable types

### DIFF
--- a/cmd/immutableGen/immMap.go
+++ b/cmd/immutableGen/immMap.go
@@ -37,7 +37,6 @@ func (o *output) genImmMaps(maps []immMap) {
 
 		// start of struct
 		o.pfln("type %v struct {", m.name)
-		o.pfln("\t//%v", immutable.ImmTypeIdentifier)
 		o.pln("")
 
 		o.pfln("theMap map[%v]%v", blanks.KeyType, blanks.ValType)

--- a/cmd/immutableGen/immSlice.go
+++ b/cmd/immutableGen/immSlice.go
@@ -35,7 +35,6 @@ func (o *output) genImmSlices(slices []immSlice) {
 
 		// start of struct
 		o.pfln("type %v struct {", s.name)
-		o.pfln("\t//%v", immutable.ImmTypeIdentifier)
 		o.pln("")
 
 		o.pfln("theSlice []%v", blanks.Type)

--- a/cmd/immutableGen/immStruct.go
+++ b/cmd/immutableGen/immStruct.go
@@ -32,7 +32,6 @@ func (o *output) genImmStructs(structs []immStruct) {
 
 		// start of struct
 		o.pfln("type %v struct {", s.name)
-		o.pfln("\t//%v", immutable.ImmTypeIdentifier)
 
 		o.printLeadSpecCommsFor(s.st)
 

--- a/cmd/immutableGen/internal/coretest/gen_core_immutableGen.go
+++ b/cmd/immutableGen/internal/coretest/gen_core_immutableGen.go
@@ -17,8 +17,6 @@ import (
 // 	map[string]int
 //
 type MyMap struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	theMap  map[string]int
 	mutable bool
 	__tmpl  _Imm_MyMap
@@ -164,8 +162,6 @@ func (m *MyMap) Del(k string) *MyMap {
 // 	[]string
 //
 type MySlice struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	theSlice []string
 	mutable  bool
 	__tmpl   _Imm_MySlice
@@ -317,8 +313,6 @@ func (m *MySlice) AppendSlice(v *MySlice) *MySlice {
 // 	}
 //
 type MyStruct struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	_Key             MyStructKey
 	_Name, _surname  string `tag:"value"`
 	_age             int    `tag:"age"`

--- a/cmd/immutableGen/internal/coretest/gen_testtypes_immutableGen_test.go
+++ b/cmd/immutableGen/internal/coretest/gen_testtypes_immutableGen_test.go
@@ -17,8 +17,6 @@ import (
 // 	map[string]int
 //
 type MyTestMap struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	theMap  map[string]int
 	mutable bool
 	__tmpl  _Imm_MyTestMap
@@ -164,8 +162,6 @@ func (m *MyTestMap) Del(k string) *MyTestMap {
 // 	[]*string
 //
 type MyTestSlice struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	theSlice []*string
 	mutable  bool
 	__tmpl   _Imm_MyTestSlice
@@ -313,7 +309,6 @@ func (m *MyTestSlice) AppendSlice(v *MyTestSlice) *MyTestSlice {
 // 	}
 //
 type MyTestStruct struct {
-	//github.com/myitcv/immutable:ImmutableType
 	//somethingspecial
 
 	_Name, _surname  string `tag:"value"`

--- a/example/gen_example_immutableGen.go
+++ b/example/gen_example_immutableGen.go
@@ -18,8 +18,6 @@ import (
 // 	map[string]MySlice
 //
 type MyMap struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	theMap  map[string]MySlice
 	mutable bool
 	__tmpl  _Imm_MyMap
@@ -165,8 +163,6 @@ func (m *MyMap) Del(k string) *MyMap {
 // 	[]MyMap
 //
 type MySlice struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	theSlice []MyMap
 	mutable  bool
 	__tmpl   _Imm_MySlice
@@ -317,8 +313,6 @@ func (m *MySlice) AppendSlice(v *MySlice) *MySlice {
 // 	}
 //
 type MyStruct struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	_Name    string `tag:"value"`
 	_surname string
 	_age     int `tag:"age"`

--- a/example/gen_example_immutableGen_test.go
+++ b/example/gen_example_immutableGen_test.go
@@ -17,8 +17,6 @@ import (
 // 	map[string]int
 //
 type myTestMap struct {
-	//github.com/myitcv/immutable:ImmutableType
-
 	theMap  map[string]int
 	mutable bool
 	__tmpl  _Imm_myTestMap

--- a/immutable.go
+++ b/immutable.go
@@ -14,9 +14,6 @@ const (
 
 	// Pkg is the import path of this package
 	PkgImportPath = "github.com/myitcv/immutable"
-
-	// ImmTypeIdentifier should not be used; instead consider using IsImmType
-	ImmTypeIdentifier = PkgImportPath + ":ImmutableType"
 )
 
 // Immutable is the interface implemented by all immutable types. If Go had generics the interface would


### PR DESCRIPTION
The special comment was previously use to identify immutable types; immutable types should instead by identified via their templates (e.g. immutableVet approach)