### PR TITLE
Separate util from core immutable package

### DIFF
--- a/cmd/immutableGen/generator.go
+++ b/cmd/immutableGen/generator.go
@@ -14,14 +14,13 @@ import (
 	"go/token"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"text/template"
 
-	"golang.org/x/tools/imports"
-
 	"github.com/myitcv/gogenerate"
-	"github.com/myitcv/immutable"
+	"github.com/myitcv/immutable/util"
 )
 
 const (
@@ -71,7 +70,7 @@ func execute(dir string, envPkg string, licenseHeader string, cmds gogenCmds) {
 		cms:       make(map[*ast.File]ast.CommentMap),
 	}
 
-	allTypes := make(map[string]immutable.ImmTypeAst)
+	allTypes := make(map[string]util.ImmTypeAst)
 
 	for fn, f := range pkg.Files {
 		// skip files that we generated
@@ -84,20 +83,20 @@ func execute(dir string, envPkg string, licenseHeader string, cmds gogenCmds) {
 		out.files[f] = og
 
 		for _, m := range og.maps {
-			allTypes[m.name] = immutable.ImmTypeAstMap{
+			allTypes[m.name] = util.ImmTypeAstMap{
 				Key:  m.keyTyp,
 				Elem: m.valTyp,
 			}
 		}
 
 		for _, s := range og.slices {
-			allTypes[s.name] = immutable.ImmTypeAstSlice{
+			allTypes[s.name] = util.ImmTypeAstSlice{
 				Elem: s.valTyp,
 			}
 		}
 
 		for _, s := range og.structs {
-			allTypes[s.name] = immutable.ImmTypeAstStruct{}
+			allTypes[s.name] = util.ImmTypeAstStruct{}
 		}
 
 		out.cms[f] = cm
@@ -121,7 +120,7 @@ type output struct {
 
 	// a convenience map of all the imm types we will
 	// be generating in this package
-	immTypes map[string]immutable.ImmTypeAst
+	immTypes map[string]util.ImmTypeAst
 
 	files map[*ast.File]*fileTmpls
 	cms   map[*ast.File]ast.CommentMap
@@ -161,7 +160,7 @@ func gatherImmTypes(pkg string, fset *token.FileSet, file *ast.File) *fileTmpls 
 		for _, s := range gd.Specs {
 			ts := s.(*ast.TypeSpec)
 
-			name, ok := immutable.IsImmTmplAst(ts)
+			name, ok := util.IsImmTmplAst(ts)
 			if !ok {
 				continue
 			}
@@ -307,9 +306,14 @@ func (o *output) genImmTypes() {
 			fatalf("could not name file from %v", fn)
 		}
 
-		formatted, err := imports.Process(fn, source, nil)
+		out := bytes.NewBuffer(nil)
+		cmd := exec.Command("gofmt", "-s")
+		cmd.Stdin = o.output
+		cmd.Stdout = out
+
+		err := cmd.Run()
 		if err == nil {
-			toWrite = formatted
+			toWrite = out.Bytes()
 		} else {
 			infof("failed to format %v: %v", fn, err)
 		}

--- a/cmd/immutableGen/immMap.go
+++ b/cmd/immutableGen/immMap.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/myitcv/immutable"
+	"github.com/myitcv/immutable/util"
 )
 
 type immMap struct {
@@ -76,7 +77,7 @@ func (o *output) genImmMaps(maps []immMap) {
 		valIsImm := o.immTypes[strings.TrimPrefix(vtyp, "*")]
 
 		if keyIsImm == nil {
-			i, err := immutable.IsImmTypeAst(m.keyTyp, m.file.Imports, m.pkg)
+			i, err := util.IsImmTypeAst(m.keyTyp, m.file.Imports, m.pkg)
 			if err != nil {
 				fatalf("failed to check IsImmTypeAst: %v", err)
 			}
@@ -84,7 +85,7 @@ func (o *output) genImmMaps(maps []immMap) {
 		}
 
 		if valIsImm == nil {
-			i, err := immutable.IsImmTypeAst(m.valTyp, m.file.Imports, m.pkg)
+			i, err := util.IsImmTypeAst(m.valTyp, m.file.Imports, m.pkg)
 			if err != nil {
 				fatalf("failed to check IsImmTypeAst: %v", err)
 			}
@@ -93,15 +94,15 @@ func (o *output) genImmMaps(maps []immMap) {
 
 		keyIsImmOk := false
 		switch keyIsImm.(type) {
-		case immutable.ImmTypeAstSlice, immutable.ImmTypeAstStruct, immutable.ImmTypeAstMap,
-			immutable.ImmTypeAstImplsIntf, immutable.ImmTypeAstExtIntf:
+		case util.ImmTypeAstSlice, util.ImmTypeAstStruct, util.ImmTypeAstMap,
+			util.ImmTypeAstImplsIntf, util.ImmTypeAstExtIntf:
 			keyIsImmOk = true
 		}
 
 		valIsImmOk := false
 		switch valIsImm.(type) {
-		case immutable.ImmTypeAstSlice, immutable.ImmTypeAstStruct, immutable.ImmTypeAstMap,
-			immutable.ImmTypeAstImplsIntf, immutable.ImmTypeAstExtIntf:
+		case util.ImmTypeAstSlice, util.ImmTypeAstStruct, util.ImmTypeAstMap,
+			util.ImmTypeAstImplsIntf, util.ImmTypeAstExtIntf:
 			valIsImmOk = true
 		}
 
@@ -139,7 +140,7 @@ func (o *output) genImmMaps(maps []immMap) {
 			}
 
 			if keyIsImmOk {
-				if _, ok := keyIsImm.(immutable.ImmTypeAstExtIntf); ok {
+				if _, ok := keyIsImm.(util.ImmTypeAstExtIntf); ok {
 					o.pt(`
 					switch k.(type) {
 					case immutable.Immutable:
@@ -158,7 +159,7 @@ func (o *output) genImmMaps(maps []immMap) {
 			}
 
 			if valIsImmOk {
-				if _, ok := valIsImm.(immutable.ImmTypeAstExtIntf); ok {
+				if _, ok := valIsImm.(util.ImmTypeAstExtIntf); ok {
 					o.pt(`
 					switch v.(type) {
 					case immutable.Immutable:

--- a/cmd/immutableGen/immSlice.go
+++ b/cmd/immutableGen/immSlice.go
@@ -6,6 +6,7 @@ import (
 	"text/template"
 
 	"github.com/myitcv/immutable"
+	"github.com/myitcv/immutable/util"
 )
 
 type immSlice struct {
@@ -72,7 +73,7 @@ func (o *output) genImmSlices(slices []immSlice) {
 		valIsImm := o.immTypes[strings.TrimPrefix(vtyp, "*")]
 
 		if valIsImm == nil {
-			i, err := immutable.IsImmTypeAst(s.valTyp, s.file.Imports, s.pkg)
+			i, err := util.IsImmTypeAst(s.valTyp, s.file.Imports, s.pkg)
 			if err != nil {
 				fatalf("failed to check IsImmTypeAst: %v", err)
 			}
@@ -80,7 +81,7 @@ func (o *output) genImmSlices(slices []immSlice) {
 		}
 
 		switch valIsImm.(type) {
-		case immutable.ImmTypeAstSlice, immutable.ImmTypeAstStruct, immutable.ImmTypeAstMap, immutable.ImmTypeAstImplsIntf:
+		case util.ImmTypeAstSlice, util.ImmTypeAstStruct, util.ImmTypeAstMap, util.ImmTypeAstImplsIntf:
 			o.pt(`
 			if s.Len() == 0 {
 				return true
@@ -99,7 +100,7 @@ func (o *output) genImmSlices(slices []immSlice) {
 			for _, v := range s.theSlice {
 			`, exp, s.name)
 
-			if _, ok := valIsImm.(immutable.ImmTypeAstExtIntf); ok {
+			if _, ok := valIsImm.(util.ImmTypeAstExtIntf); ok {
 				o.pt(`
 					switch v := v.(type) {
 					case immutable.Immutable:

--- a/cmd/immutableGen/immStruct.go
+++ b/cmd/immutableGen/immStruct.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/myitcv/immutable"
+	"github.com/myitcv/immutable/util"
 )
 
 type commonImm struct {
@@ -34,7 +35,7 @@ func (o *output) genImmStructs(structs []immStruct) {
 		Name  string
 		Type  string
 		f     *ast.Field
-		IsImm immutable.ImmTypeAst
+		IsImm util.ImmTypeAst
 	}
 
 	for _, s := range structs {
@@ -55,13 +56,13 @@ func (o *output) genImmStructs(structs []immStruct) {
 			names := ""
 			sep := ""
 
-			var isImm immutable.ImmTypeAst
+			var isImm util.ImmTypeAst
 			typ := o.exprString(f.Type)
 
 			isImm = o.immTypes[strings.TrimPrefix(typ, "*")]
 
 			if isImm == nil {
-				i, err := immutable.IsImmTypeAst(f.Type, s.file.Imports, s.pkg)
+				i, err := util.IsImmTypeAst(f.Type, s.file.Imports, s.pkg)
 				if err != nil {
 					panic(err)
 				}
@@ -100,7 +101,7 @@ func (o *output) genImmStructs(structs []immStruct) {
 				}
 			}
 			switch isImm.(type) {
-			case immutable.ImmTypeAstMap, immutable.ImmTypeAstSlice, immutable.ImmTypeAstStruct:
+			case util.ImmTypeAstMap, util.ImmTypeAstSlice, util.ImmTypeAstStruct:
 				o.pln("// isImm")
 			}
 			o.pfln("%v %v %v", names, typ, tag)
@@ -197,7 +198,7 @@ func (o *output) genImmStructs(structs []immStruct) {
 
 		for _, f := range fields {
 			switch f.IsImm.(type) {
-			case immutable.ImmTypeAstSlice, immutable.ImmTypeAstStruct, immutable.ImmTypeAstMap, immutable.ImmTypeAstImplsIntf:
+			case util.ImmTypeAstSlice, util.ImmTypeAstStruct, util.ImmTypeAstMap, util.ImmTypeAstImplsIntf:
 
 				tmpl := struct {
 					TypeName string
@@ -216,7 +217,7 @@ func (o *output) genImmStructs(structs []immStruct) {
 					}
 				}
 				`, exp, tmpl)
-			case immutable.ImmTypeAstExtIntf:
+			case util.ImmTypeAstExtIntf:
 
 				tmpl := struct {
 					TypeName string

--- a/cmd/immutableGen/immutableGen_test.go
+++ b/cmd/immutableGen/immutableGen_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	"github.com/myitcv/gogenerate"
-	"github.com/myitcv/immutable"
+	"github.com/myitcv/immutable/util"
 )
 
 const (
@@ -71,7 +71,7 @@ func TestBasic(t *testing.T) {
 		for _, s := range gd.Specs {
 			ts := s.(*ast.TypeSpec)
 
-			name, ok := immutable.IsImmTmplAst(ts)
+			name, ok := util.IsImmTmplAst(ts)
 
 			if !ok {
 				continue

--- a/cmd/immutableVet/immutableVet.go
+++ b/cmd/immutableVet/immutableVet.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kisielk/gotool"
 	"github.com/myitcv/gogenerate"
 	"github.com/myitcv/immutable"
+	"github.com/myitcv/immutable/util"
 )
 
 const (
@@ -188,8 +189,8 @@ func vet(wd string, specs []string) []immErr {
 func (iv *immutableVetter) ensurePointerTyp(n ast.Node, typ ast.Expr) {
 	t := iv.info.Types[typ].Type
 	p := types.NewPointer(t)
-	switch immutable.IsImmType(p).(type) {
-	case immutable.ImmTypeMap, immutable.ImmTypeSlice, immutable.ImmTypeStruct:
+	switch util.IsImmType(p).(type) {
+	case util.ImmTypeMap, util.ImmTypeSlice, util.ImmTypeStruct:
 		iv.errorf(n.Pos(), "type should be %v", p)
 	}
 }
@@ -227,8 +228,8 @@ func (iv *immutableVetter) Visit(node ast.Node) ast.Visitor {
 
 		t := iv.info.Types[cl.Type].Type
 		p := types.NewPointer(t)
-		switch immutable.IsImmType(p).(type) {
-		case immutable.ImmTypeMap, immutable.ImmTypeSlice, immutable.ImmTypeStruct:
+		switch util.IsImmType(p).(type) {
+		case util.ImmTypeMap, util.ImmTypeSlice, util.ImmTypeStruct:
 			iv.errorf(node.Pos(), "construct using new() or generated constructors")
 			iv.vcls[cl] = true
 		}
@@ -397,8 +398,8 @@ func (iv *immutableVetter) Visit(node ast.Node) ast.Visitor {
 }
 
 func isImmListOrMap(t types.Type) bool {
-	switch immutable.IsImmType(t).(type) {
-	case immutable.ImmTypeMap, immutable.ImmTypeSlice:
+	switch util.IsImmType(t).(type) {
+	case util.ImmTypeMap, util.ImmTypeSlice:
 		return true
 	}
 
@@ -473,7 +474,7 @@ func (iv *immutableVetter) vetPackages() []immErr {
 				for _, s := range gd.Specs {
 					ts := s.(*ast.TypeSpec)
 
-					_, ok := immutable.IsImmTmplAst(ts)
+					_, ok := util.IsImmTmplAst(ts)
 					if !ok {
 						continue
 					}
@@ -519,10 +520,10 @@ func (iv *immutableVetter) vetPackages() []immErr {
 
 			case t.IsValue():
 				p := types.NewPointer(t.Type)
-				switch immutable.IsImmType(p).(type) {
-				case immutable.ImmTypeMap:
-				case immutable.ImmTypeSlice:
-				case immutable.ImmTypeStruct:
+				switch util.IsImmType(p).(type) {
+				case util.ImmTypeMap:
+				case util.ImmTypeSlice:
+				case util.ImmTypeStruct:
 				default:
 					continue
 				}
@@ -543,7 +544,7 @@ func (iv *immutableVetter) vetPackages() []immErr {
 				continue
 			}
 
-			if immutable.IsImmType(sel.Recv()) == nil {
+			if util.IsImmType(sel.Recv()) == nil {
 				continue
 			}
 
@@ -585,7 +586,7 @@ func isImmType(t types.Type) bool {
 	case *types.Map, *types.Slice:
 		return false
 	case *types.Pointer:
-		return immutable.IsImmType(t) != nil
+		return util.IsImmType(t) != nil
 	case *types.Struct:
 		for i := 0; i < t.NumFields(); i++ {
 			f := t.Field(i)

--- a/util/ast.go
+++ b/util/ast.go
@@ -1,4 +1,4 @@
-package immutable
+package util
 
 import (
 	"bytes"
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	"github.com/myitcv/immutable"
 )
 
 const (
@@ -22,7 +24,7 @@ const (
 func IsImmTmplAst(ts *ast.TypeSpec) (string, bool) {
 	typName := ts.Name.Name
 
-	if !strings.HasPrefix(typName, ImmTypeTmplPrefix) {
+	if !strings.HasPrefix(typName, immutable.ImmTypeTmplPrefix) {
 		return "", false
 	}
 
@@ -43,7 +45,7 @@ func IsImmTmplAst(ts *ast.TypeSpec) (string, bool) {
 		return "", false
 	}
 
-	name := strings.TrimPrefix(typName, ImmTypeTmplPrefix)
+	name := strings.TrimPrefix(typName, immutable.ImmTypeTmplPrefix)
 
 	return name, true
 }
@@ -300,7 +302,7 @@ func isAstTypeImm(pkgStr, typStr string, isPointer bool) (ImmTypeAst, error) {
 
 						case "__tmpl":
 							n, ok := f.Type.(*ast.Ident)
-							if ok && n.Name == ImmTypeTmplPrefix+typStr {
+							if ok && n.Name == immutable.ImmTypeTmplPrefix+typStr {
 								foundTmpl = true
 							}
 

--- a/util/types.go
+++ b/util/types.go
@@ -1,4 +1,4 @@
-package immutable
+package util
 
 import (
 	"go/types"


### PR DESCRIPTION
This allows us to drop any sort of `golang.org/x/tools` dependency from `github.com/myitcv/immutable`