### PR TITLE
cmd/immutableGen: properly handle non-exported setters.

### DIFF
--- a/cmd/immutableGen/immStruct.go
+++ b/cmd/immutableGen/immStruct.go
@@ -295,7 +295,21 @@ func (o *output) genImmStructs(structs []*immStruct) {
 							rp = rp + "."
 						}
 						sp := strings.TrimSuffix(p, "()")
-						o.pf("%v := s.%vSet%v(%v)\n", v, rp, sp, last)
+
+						tmpl := struct {
+							V    string
+							Rp   string
+							Sp   string
+							Last string
+						}{
+							V:    v,
+							Rp:   rp,
+							Sp:   sp,
+							Last: last,
+						}
+						exp := exporter(sp)
+						o.pt(`{{.V}} := s.{{.Rp}}{{Export "Set"}}{{Capitalise .Sp}}({{.Last}})
+						`, exp, tmpl)
 					} else {
 						o.pf("%v := s.%v\n", v, rp)
 						o.pf("%v.%v = %v\n", v, p, last)

--- a/cmd/immutableGen/immutableGen.go
+++ b/cmd/immutableGen/immutableGen.go
@@ -24,7 +24,7 @@ var (
 )
 
 const (
-	debug = true
+	debug = false
 )
 
 func init() {

--- a/cmd/immutableGen/method_sets.go
+++ b/cmd/immutableGen/method_sets.go
@@ -79,7 +79,6 @@ func (o *output) calcMethodSets() {
 					if _, ok := possSet[name]; ok {
 						possSet[name] = nil
 					} else {
-						fmt.Printf("addPoss %v\n", name)
 						f.path = append(append([]string(nil), h.path...), f.path...)
 						possSet[name] = &f
 					}
@@ -153,7 +152,6 @@ func (o *output) calcMethodSets() {
 					debugf("using type check on %T %v\n", h.typ, h.typ)
 					if v, ok := util.IsImmType(h.typ).(util.ImmTypeStruct); ok {
 						is := v.Struct
-						fmt.Printf("))) %v %v\n", h.typ, is.NumFields())
 						for i := 0; i < is.NumFields(); i++ {
 							f := is.Field(i)
 							name := f.Name()
@@ -183,10 +181,8 @@ func (o *output) calcMethodSets() {
 							}
 						}
 					} else if v, ok := h.typ.Underlying().(*types.Struct); ok {
-						fmt.Printf("))) %v %v\n", h.typ, v.NumFields())
 						for i := 0; i < v.NumFields(); i++ {
 							f := v.Field(i)
-							fmt.Printf("::: %v %v %v\n", f.Name(), f.Exported(), f.Anonymous())
 							if !f.Exported() {
 								continue
 							}


### PR DESCRIPTION
We still don't fully support struct embedding because to do so we would
need to work out whether a field should be imported based on more than
whether it is simply exported. Because if the embedded struct belongs to
the same package. Don't need this for now so simply relying on Exported
which will, at worse, give us a subset of the actually embedded fields.